### PR TITLE
fix: FST_ERR_DEC_ALREADY_PRESENT

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ module.exports = fp(
   async function (fastify) {
     await fastify.register(require('@fastify/static'), {
       root: path.join(__dirname, 'dist'),
-      prefix: '/fastify-overview-ui/'
+      prefix: '/fastify-overview-ui/',
+      decorateReply: false
     })
     fastify.get('/json-overview-ui', async () => fastify.overview())
   },


### PR DESCRIPTION
if the user has already registered the `@fastify/static` the error is triggered:

```
FastifyError [Error]: The decorator 'sendFile' has already been added!
    at decorateConstructor (/Users/mspigolon/workspace/_experiments/firenze-commit/node_modules/fastify/lib/decorate.js:40:11)
```

this option fixes this use case
