### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "fastify": "^4.4.0",
         "fastify-overview": "^3.1.0",
-        "husky": "^9.0.6",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.1",
         "pre-commit": "^1.2.2",
         "prettier": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "lint": "eslint . --ext=.js,.jsx",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "tap test"
   },
   "dependencies": {
@@ -35,7 +35,7 @@
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "fastify": "^4.4.0",
     "fastify-overview": "^3.1.0",
-    "husky": "^9.0.6",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.1",
     "pre-commit": "^1.2.2",
     "prettier": "^3.0.1",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)