### PR TITLE
fix(lint): lint .jsx files and correct lint-staged glob

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,13 +6,19 @@ export default [
   js.configs.recommended,
   prettierRecommended,
   {
+    files: ['**/*.{js,jsx}'],
     languageOptions: {
       globals: {
         ...globals.node,
         ...globals.browser
       },
       ecmaVersion: 'latest',
-      sourceType: 'module'
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      }
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
   },
   "homepage": "https://github.com/nearform/fastify-overview-ui#readme",
   "lint-staged": {
-    "*.js(x)": "eslint --cache --fix"
+    "*.{js,jsx}": "eslint --cache --fix"
   }
 }


### PR DESCRIPTION
Closes #913

Two related lint bugs from the recent eslint 10 bump:

- `eslint.config.js` set no `files` pattern, so eslint fell back to its default `**/*.{js,mjs,cjs}` and silently skipped every `.jsx` source (10 files: `src/App.jsx`, `src/index.jsx`, `src/components/*.jsx`, `src/store/index.jsx`). Add a `files: ['**/*.{js,jsx}']` block with `parserOptions.ecmaFeatures.jsx` so JSX is parsed.
- `lint-staged` glob `*.js(x)` only matches `.jsx`, so the pre-commit hook covered exactly the files eslint ignored and ignored exactly the files eslint checked (including `eslint.config.js` itself). Switch it to `*.{js,jsx}`.

Verified: `npm run lint` now parses every `.jsx` file with no syntax errors, `npm test` passes (after `npm run build`), and the pre-commit hook runs eslint over both `.js` and `.jsx`.